### PR TITLE
optimization in git clone using --depth

### DIFF
--- a/os/booting-on-launchtimevps.md
+++ b/os/booting-on-launchtimevps.md
@@ -51,10 +51,10 @@ A VM can be reinstalled (with a fresh/clean Container Linux image and different 
 
 Set your public [SSH keys][rh-ssh-keys-page].
 
-Git clone the [Python driver for the RimuHosting API][rh-python-driver-api]:
+git clone --depth 1 the [Python driver for the RimuHosting API][rh-python-driver-api]:
 
 ```sh
-git clone git@github.com:pbkwee/RimuHostingAPI.git
+git clone --depth 1 git@github.com:pbkwee/RimuHostingAPI.git
 ```
 
 Install the library:

--- a/os/booting-on-vagrant.md
+++ b/os/booting-on-vagrant.md
@@ -19,7 +19,7 @@ Now that you have Vagrant installed you can bring up a Container Linux instance.
 The following commands will clone a repository that contains the Container Linux Vagrantfile. This file tells Vagrant where it can find the latest disk image of Container Linux. Vagrant will download the image the first time you attempt to start the VM.
 
 ```sh
-git clone https://github.com/coreos/coreos-vagrant.git
+git clone --depth 1 https://github.com/coreos/coreos-vagrant.git
 cd coreos-vagrant
 ```
 


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>